### PR TITLE
adjust print button styling 

### DIFF
--- a/base/config/aidbox/init-bundle.json
+++ b/base/config/aidbox/init-bundle.json
@@ -310,6 +310,10 @@
           "hierarchy-padding": 0
         },
         "theme-name": "WA DOH Theme",
+        "button": {
+          "print-color": "#eee",
+          "print-text-color": "#eee"
+        },
         "brand-image": {
           "top-right": {
             "url": "https://uwcirg.github.io/cirg.washington.edu/images/logos/DOH_logo_primary_122122_pic.jpg"


### PR DESCRIPTION
As request from [Slack convo](https://cirg.slack.com/archives/C0A8YGYRA9L/p1770752817525479)
- adjust print button so it is not visible.
(see screenshot) from my instance
<img width="949" height="71" alt="Screenshot 2026-02-10 at 12 20 36 PM" src="https://github.com/user-attachments/assets/c9539616-25b8-482e-b08f-6b68be74acd5" />





Tested by performing a PUT using the following JSON in my instance, e.g. `curl -X PUT -H 'Content-Type: application/json' -d "@AidBox_Theme.json" 'https://aidbox.hpai.ubu.clone.dev.cirg.uw.edu/fhir/QuestionnaireTheme/wa-doh-theme'`
```
{
  "input": { "font-size": 14, "hierarchy-padding": 0 },
  "theme-name": "WA DOH Theme",
  "brand-image": {
    "top-right": {
      "url": "https://uwcirg.github.io/cirg.washington.edu/images/logos/DOH_logo_primary_122122_pic.jpg"
    },
    "bottom-left": {
      "url": "https://uwcirg.github.io/cirg.washington.edu/images/logos/DOH_logo_primary_122122_words2.png"
    }
  },
  "button": {
    "print-color": "#eee",
    "print-text-color": "#eee"
  },
  "base-font-size": 14,
  "id": "wa-doh-theme",
  "resourceType": "QuestionnaireTheme",
  "meta": {
    "lastUpdated": "2026-01-30T18:12:39.021562Z",
    "versionId": "10",
    "extension": [
      {
        "url": "https://aidbox.app/ex/createdAt",
        "valueInstant": "2026-01-30T18:12:39.021562Z"
      }
    ]
  }
}
```
