### PR TITLE
Adds ViewDefinition and AidboxQuery to init-bundle.json - SQL on FHIR

### DIFF
--- a/base/config/aidbox/init-bundle.json
+++ b/base/config/aidbox/init-bundle.json
@@ -360,8 +360,8 @@
     {
       "resource": {
         "resourceType": "ViewDefinition",
-        "id": "hpai_questionnaire_report",
-        "name": "hpai_questionnaire_report",
+        "id": "vd_qr_hpai",
+        "name": "vd_qr_hpai",
         "resource": "QuestionnaireResponse",
         "status": "active",
         "where": [
@@ -387,18 +387,71 @@
         ]
       },
       "request": {
-        "method": "PUT",
-        "url": "/ViewDefinition/hpai_questionnaire_report"
+        "method": "POST",
+        "url": "/ViewDefinition"
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "ViewDefinition/vd_qr_hpai/$materialize"
+      },
+      "resource": {
+        "resourceType": "Parameters",
+        "parameter": [
+          {
+            "name": "type",
+            "valueCode": "view"
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "ViewDefinition",
+        "id": "vd_patient_simple",
+        "name": "vd_patient_simple",
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              { "name": "patient_id", "path": "id" },
+              { "name": "name_given", "path": "name[0].given[0]" },
+              { "name": "name_family", "path": "name[0].family" },
+              { "name": "birthdate", "path": "birthDate" }
+            ]
+          }
+        ]
+      },
+      "request": {
+        "method": "POST",
+        "url": "/ViewDefinition"
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "ViewDefinition/vd_patient_simple/$materialize"
+      },
+      "resource": {
+        "resourceType": "Parameters",
+        "parameter": [
+          {
+            "name": "type",
+            "valueCode": "view"
+          }
+        ]
       }
     },
     {
       "resource": {
         "resourceType": "AidboxQuery",
-        "query": "select * from sof.hpai_questionnaire_report"
+        "query": "select pt.name_family, pt.name_given, pt.birthdate, qr.authored, qr.contact_with_infected_person, qr.contact_with_infected_person_notes, qr.contact_with_sick_dead_animals, qr.contact_with_sick_dead_animals_notes, qr.patient_setting, qr.raw_animal_foods, qr.raw_animal_foods_notes, pt.patient_id, qr.qr_id from sof.vd_patient_simple pt join sof.vd_qr_hpai qr on qr.patient_id = pt.patient_id;"
       },
       "request": {
         "method": "PUT",
-        "url": "/AidboxQuery/hpai_qr_report_query"
+        "url": "/AidboxQuery/aidboxquery_hpai_qr_report"
       }
     }
   ]

--- a/base/config/aidbox/init-bundle.json
+++ b/base/config/aidbox/init-bundle.json
@@ -360,7 +360,7 @@
     {
       "resource": {
         "resourceType": "ViewDefinition",
-        "id": "hpai-questionnaire-report",
+        "id": "hpai_questionnaire_report",
         "name": "hpai_questionnaire_report",
         "resource": "QuestionnaireResponse",
         "status": "active",
@@ -388,18 +388,17 @@
       },
       "request": {
         "method": "PUT",
-        "url": "/ViewDefinition/hpai-questionnaire-report"
+        "url": "/ViewDefinition/hpai_questionnaire_report"
       }
     },
     {
       "resource": {
         "resourceType": "AidboxQuery",
-        "id": "hpai-questionnaire-report",
         "query": "select * from sof.hpai_questionnaire_report"
       },
       "request": {
         "method": "PUT",
-        "url": "/AidboxQuery/hpai-questionnaire-report"
+        "url": "/AidboxQuery/hpai_qr_report_query"
       }
     }
   ]

--- a/base/config/aidbox/init-bundle.json
+++ b/base/config/aidbox/init-bundle.json
@@ -390,6 +390,17 @@
         "method": "PUT",
         "url": "/ViewDefinition/hpai-questionnaire-report"
       }
+    },
+    {
+      "resource": {
+        "resourceType": "AidboxQuery",
+        "id": "hpai-questionnaire-report",
+        "query": "select * from sof.hpai_questionnaire_report"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "/AidboxQuery/hpai-questionnaire-report"
+      }
     }
   ]
 }

--- a/base/config/aidbox/init-bundle.json
+++ b/base/config/aidbox/init-bundle.json
@@ -356,6 +356,40 @@
         "method": "PUT",
         "url": "/SDCConfig/wa-doh-sdcconfig"
       }
+    },
+    {
+      "resource": {
+        "resourceType": "ViewDefinition",
+        "id": "hpai-questionnaire-report",
+        "name": "hpai_questionnaire_report",
+        "resource": "QuestionnaireResponse",
+        "status": "active",
+        "where": [
+          {
+            "path": "questionnaire = 'http://forms.aidbox.io/questionnaire/hpai-provider-questionnaire'"
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              { "name": "qr_id", "path": "id" },
+              { "name": "authored", "path": "authored" },
+              { "name": "patient_id", "path": "subject.id" },
+              { "name": "contact_with_infected_person", "path": "item.where(linkId='hpai-0').answer.value.ofType(Coding).display" },
+              { "name": "contact_with_infected_person_notes", "path": "item.where(linkId='hpai-0').answer.item.where(linkId='hpai-0B').answer.value.ofType(string)" },
+              { "name": "contact_with_sick_dead_animals", "path": "item.where(linkId='hpai-1').answer.value.ofType(Coding).display" },
+              { "name": "contact_with_sick_dead_animals_notes", "path": "item.where(linkId='hpai-1').answer.item.where(linkId='hpai-1B').answer.value.ofType(string)" },
+              { "name": "patient_setting", "path": "item.where(linkId='hpai-setting').answer.value.ofType(Coding).display" },
+              { "name": "raw_animal_foods", "path": "item.where(linkId='hpai-3').answer.value.ofType(Coding).display" },
+              { "name": "raw_animal_foods_notes", "path": "item.where(linkId='hpai-3').answer.item.where(linkId='hpai-3B').answer.value.ofType(string)" }
+            ]
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "/ViewDefinition/hpai-questionnaire-report"
+      }
     }
   ]
 }

--- a/base/config/aidbox/sample-hpai-qr.json
+++ b/base/config/aidbox/sample-hpai-qr.json
@@ -1,0 +1,136 @@
+{
+  "questionnaire": "http://forms.aidbox.io/questionnaire/hpai-provider-questionnaire",
+  "meta": {
+    "lastUpdated": "2026-02-26T22:53:15.293790Z",
+    "versionId": "588",
+    "extension": [
+      {
+        "url": "https://aidbox.app/ex/createdAt",
+        "valueInstant": "2026-02-26T22:51:48.967669Z"
+      }
+    ]
+  },
+  "item": [
+    {
+      "text": "WA DOH suggests that healthcare systems add the following screening questions for patients with ILI:\n\n  \nIn the **10 days before symptom onset**, has the patient had: ",
+      "linkId": "OZeDhhS5"
+    },
+    {
+      "text": "...contact (within 6 feet) with a **person who is suspected or confirmed to** have avian influenza, also called \"bird flu\"?",
+      "answer": [
+        {
+          "item": [
+            {
+              "text": "Please add brief notes for the public health investigator",
+              "answer": [
+                {
+                  "valueString": "Yes, my roommate tested positive."
+                }
+              ],
+              "linkId": "hpai-0B"
+            }
+          ],
+          "valueCoding": {
+            "code": "hpai-0-yes",
+            "display": "Yes"
+          }
+        }
+      ],
+      "linkId": "hpai-0"
+    },
+    {
+      "text": "...close contact with  **sick or dead animals** or their environments, including birds, wildlife, livestock (e.g., cows, pigs, or poultry), or domestic cats?",
+      "answer": [
+        {
+          "item": [
+            {
+              "text": "Please add brief notes for the public health investigator",
+              "answer": [
+                {
+                  "valueString": "I think so - we have a backyard chicken shed."
+                }
+              ],
+              "linkId": "hpai-1B"
+            }
+          ],
+          "valueCoding": {
+            "code": "hpai-1-yes",
+            "display": "Yes"
+          }
+        }
+      ],
+      "linkId": "hpai-1"
+    },
+    {
+      "text": "### Use contact, droplet, and airborne precautions with eye protection (goggles or face shield). If possible, isolate the patient in an airborne infection isolation room (AIIR; negative pressure room).\n \n \nThis patient has a **Notifiable condition in WA State** and should be reported to your local health department.",
+      "linkId": "hpai-rec-0"
+    },
+    {
+      "text": "Is the patient in an outpatient or inpatient setting?",
+      "answer": [
+        {
+          "item": [
+            {
+              "text": "#### This link offers information about outpatient isolation protocols (this URL is just an example): \n\n[https://www.cdc.gov/bird-flu/hcp/clinicians-evaluating-patients/](https://www.cdc.gov/bird-flu/hcp/clinicians-evaluating-patients/)",
+              "linkId": "kHqagscX"
+            }
+          ],
+          "valueCoding": {
+            "code": "hpai-setting-out",
+            "display": "Outpatient"
+          }
+        }
+      ],
+      "linkId": "hpai-setting"
+    },
+    {
+      "text": "_______________________________",
+      "linkId": "Ao2sQ8Sr"
+    },
+    {
+      "text": "Has the patient consumed or handled **raw animal foods for humans or pets** (e.g., raw cow milk, cheeses or other products made with raw cow milk, raw meat, or raw meat-based pet food)?",
+      "answer": [
+        {
+          "item": [
+            {
+              "text": "Please add brief notes for the public health investigator",
+              "answer": [
+                {
+                  "valueString": "Yes, raw goat milk."
+                }
+              ],
+              "linkId": "hpai-3B"
+            }
+          ],
+          "valueCoding": {
+            "code": "hpai-3-yes",
+            "display": "Yes"
+          }
+        }
+      ],
+      "linkId": "hpai-3"
+    }
+  ],
+  "resourceType": "QuestionnaireResponse",
+  "author": {
+    "identifier": {
+      "type": {
+        "coding": [
+          {
+            "code": "UID",
+            "system": "urn:system:aidbox",
+            "display": "User ID"
+          }
+        ]
+      },
+      "value": "admin",
+      "system": "https://aidbox.hpai.doh.dev.cirg.uw.edu"
+    }
+  },
+  "status": "completed",
+  "id": "6ce170e3-36b9-4f71-89b3-d495ae4ffb10",
+  "authored": "2026-02-26T22:53:13.432Z",
+  "subject": {
+    "reference": "Patient/185337c5-82bb-47c8-9393-13f0c43dfb45"
+  }
+}

--- a/base/docker-compose.yaml
+++ b/base/docker-compose.yaml
@@ -37,7 +37,7 @@ services:
     environment:
       REACT_APP_CONF_API_URL: https://confidentialbackend.${BASE_DOMAIN}
       REACT_APP_DASHBOARD_URL: https://femr.${BASE_DOMAIN}
-      REACT_APP_REPORT_URL: https://aidbox.${BASE_DOMAIN}/$$query/aidboxquery_hpai_qr_report
+      REACT_APP_FHIR_URL: https://aidbox.${BASE_DOMAIN}
       REACT_APP_SYSTEM_TYPE: development
       REACT_APP_QUESTIONNAIRE_ID: hpai-provider-questionnaire
     labels:

--- a/base/docker-compose.yaml
+++ b/base/docker-compose.yaml
@@ -37,6 +37,7 @@ services:
     environment:
       REACT_APP_CONF_API_URL: https://confidentialbackend.${BASE_DOMAIN}
       REACT_APP_DASHBOARD_URL: https://femr.${BASE_DOMAIN}
+      REACT_APP_REPORT_URL: https://aidbox.${BASE_DOMAIN}/$$query/aidboxquery_hpai_qr_report
       REACT_APP_SYSTEM_TYPE: development
       REACT_APP_QUESTIONNAIRE_ID: hpai-provider-questionnaire
     labels:


### PR DESCRIPTION
Adds ViewDefinition and AidboxQuery to init-bundle.json - SQL on FHIR.

For QuestionnaireResponse from the HPAI qnr. Also adds a sample HPAI QR.

First commit was vibe-coded with Claude Opus 4.6, but that was the easy part. 

Once the ViewDefinition has been created, the DB view needs to be created...  thus the `ViewDefinition/[id]/$materialize` call.

References:
https://www.health-samurai.io/docs/aidbox/modules/aidbox-forms/aidbox-ui-builder-alpha/building-reports-using-sql-on-fhir - basically, followed this process.
https://www.health-samurai.io/docs/aidbox/modules/sql-on-fhir/defining-flat-views-with-view-definitions

`$materialize` docs:
https://www.health-samurai.io/docs/aidbox/modules/sql-on-fhir/operation-materialize#using-a-bundle

I found that I needed to mess around with this UI to get the 'view' created:
<img width="1653" height="585" alt="image" src="https://github.com/user-attachments/assets/5678ceae-f88c-426f-93f8-cfc366be19ca" />


Run of the AidboxQuery https://aidbox.hpai.doh.dev.cirg.uw.edu/$query/aidboxquery_hpai_qr_report :
<img width="736" height="530" alt="image" src="https://github.com/user-attachments/assets/210a8fe1-d62b-4578-b8c6-3b60beaee78b" />
